### PR TITLE
Add test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Stories in Ready](https://badge.waffle.io/TechNottingham/Hackbot.svg?label=ready&title=Ready)](http://waffle.io/TechNottingham/Hackbot)
+[![Build Status]](https://semaphoreci.com/codesleuth/hack24-api) [![Stories in Ready]](http://waffle.io/TechNottingham/Hackbot)
 
 # Hack24-API
 An API for storing users, teams, hacks, challenges and sponsors
@@ -53,3 +53,6 @@ You will need installations of the following:
     ```
 
 7. Open a pull request!
+
+[Build Status]: https://semaphoreci.com/api/v1/codesleuth/hack24-api/branches/master/badge.svg
+[Stories in Ready]: https://badge.waffle.io/TechNottingham/Hackbot.svg?label=ready&title=Ready

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,6 +1,8 @@
-var Server = require('../build/server/server');
+require('source-map-support').install();
 
-const server = new Server.Server();
+var Server = require('../build/server/server').Server;
+
+var server = new Server();
 server.listen()
       .then((info) => {
         console.log(`Server started on port ${info.Port}`)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,20 +22,20 @@ function gulpPrint(data) {
 function compile(projectPath, watch, done) {
   var args = ['--project', projectPath]
   if (watch === true) args.push('-w')
-  
+
   var tsc = spawn(getBinary('tsc'), args, { cwd: process.cwd() })
-  
+
   tsc.stdout.setEncoding('utf8')
   tsc.stderr.setEncoding('utf8')
-  
+
   tsc.stdout.on('data', gulpPrint)
   tsc.stderr.on('data', gulpPrint)
-  
+
   tsc.on('close', function (code) {
     if (code !== 0) return done(new Error('tsc finished with non-zero exit code (' + code + ')'))
     done(null)
   })
-  
+
   tsc.on('error', done)
 }
 
@@ -49,7 +49,11 @@ gulp.task('build:server', ['clean'], function (done) {
   compile('src/server', false, done)
 })
 
-gulp.task('build', ['build:server'])
+gulp.task('build:test', ['clean'], function (done) {
+  compile('src/test', false, done)
+})
+
+gulp.task('build', ['build:server', 'build:test'])
 
 
 
@@ -57,7 +61,8 @@ gulp.task('build:server:watch', function (done) {
   compile('src/server', true, done)
 })
 
-gulp.task('watch', ['build:server:watch'])
+gulp.task('build:test:watch', function (done) {
+  compile('src/test', true, done)
+})
 
-
-gulp.task('test', [])
+gulp.task('watch', ['build:server:watch', 'build:test:watch'])

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "bin/server.js",
   "scripts": {
     "start": "node --use_strict .",
-    "postinstall": "cd src/server && typings install && gulp build"
+    "postinstall": "cd src/server && typings install && cd ../test && typings install && gulp build",
+    "test": "cd build && mocha --require source-map-support/register --use_strict -R spec"
   },
   "dependencies": {
     "body-parser": "^1.14.2",
@@ -15,7 +16,11 @@
     "gulp": "^3.9.0",
     "gulp-util": "^3.0.7",
     "mongoose": "^4.3.7",
+    "source-map-support": "^0.4.0",
     "typescript": "^1.7.5",
     "typings": "^0.6.5"
+  },
+  "devDependencies": {
+    "mocha": "^2.4.5"
   }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -59,5 +59,13 @@ export class Server {
       });
     });
   }
+  
+  close(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this._server.close(() => {
+        resolve();
+      });
+    });
+  }
 }
 

--- a/src/test/setup.test.ts
+++ b/src/test/setup.test.ts
@@ -1,0 +1,112 @@
+import * as assert from 'assert';
+import {spawn, fork, ChildProcess} from 'child_process';
+import * as mongoose from 'mongoose';
+
+class ApiServer {
+  private static _api: ChildProcess;
+  
+  static start(): void {
+    
+    console.log('Starting API server...');
+    
+    this._api = fork('../server/server', [], {
+      cwd: process.cwd(),
+      env: { PORT: 12123 }
+    })
+  
+    if (process.env.DEBUG) {
+      this._api.stdout.setEncoding('utf8');
+      this._api.stderr.setEncoding('utf8');
+      this._api.stdout.on('data', console.log);
+      this._api.stderr.on('data', console.error);
+    }
+  
+    this._api.on('close', function (code) {
+      if (code !== 0) return console.error(new Error('API closed with non-zero exit code (' + code + ')'));
+      console.log('API closed.');
+    });
+  
+    this._api.on('error', (err) => {
+      throw new Error('Unable to start API: ' + err.message);
+    });
+  }
+  
+  static stop(): void {
+    if (!this._api) return;
+    console.log('Stopping API server...');
+    this._api.kill('SIGINT');
+  }
+}
+
+class MongoDb {
+  private static _spawn: ChildProcess;
+  
+  static start(cb: (err?) => void): void {
+    mongoose.connection.once('open', (ref) => {
+      cb();
+    });
+    
+    let errors = 0;
+    
+    mongoose.connection.on('error', (err) => {
+      if (errors > 0) return cb(new Error('Unable to spin up MongoDB.'));
+      errors++;
+      this._spawn = this.spawn();
+      this.connectMongo();
+    });
+    
+    this.connectMongo();
+  }
+  
+  private static connectMongo() {
+    mongoose.connect(process.env.MONGODB_URL || 'mongodb://localhost/hack24db');
+  }
+  
+  private static spawn() {
+    console.log('Starting MongoDB server...');
+      
+    let mongod = spawn('mongod');
+    
+    if (process.env.DEBUG) {
+      mongod.stdout.setEncoding('utf8');
+      mongod.stderr.setEncoding('utf8');
+    
+      mongod.stdout.on('data', console.log);
+      mongod.stderr.on('data', console.error);
+    }
+  
+    mongod.on('close', function (code) {
+      if (code !== 0) return console.error(new Error('MongoDB finished with non-zero exit code (' + code + ')'));
+      console.log('MongoDB closed.');
+    });
+  
+    mongod.on('error', (err) => {
+      throw new Error('Unable to start MongoDB: ' + err.message);
+    });
+    
+    return mongod;
+  } 
+  
+  static stop(): void {
+    if (!this._spawn) {
+      mongoose.connection.close();
+      return;
+    }    
+    
+    console.log('Stopping MongoDB server...');
+    this._spawn.kill('SIGINT');
+  }
+}
+
+before((done) => {
+  MongoDb.start((err) => {
+    if (err) return done(err);
+    ApiServer.start();
+    done();
+  });
+});
+
+after(() => {
+  ApiServer.stop();
+  MongoDb.stop();
+});

--- a/src/test/tsconfig.json
+++ b/src/test/tsconfig.json
@@ -5,5 +5,9 @@
     "removeComments": true,
     "outDir": "../../build/test",
     "sourceMap": true
-  }
+  },
+  "exclude": [
+    "typings/browser.d.ts",
+    "typings/browser"
+  ]
 }

--- a/src/test/typings.json
+++ b/src/test/typings.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {},
+  "devDependencies": {},
+  "ambientDependencies": {
+    "mocha": "github:DefinitelyTyped/DefinitelyTyped/mocha/mocha.d.ts#d6dd320291705694ba8e1a79497a908e9f5e6617",
+    "mongoose": "github:DefinitelyTyped/DefinitelyTyped/mongoose/mongoose.d.ts#97ec10cb6c917dce7668f3833679506162c0f5c4",
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#1c56e368e17bb28ca57577250624ca5bd561aa81"
+  }
+}

--- a/src/test/users.test.ts
+++ b/src/test/users.test.ts
@@ -1,0 +1,17 @@
+import * as assert from 'assert';
+
+describe('Users resource', () => {
+  
+  describe('Get all users', () => {
+    
+    before(() => {
+      
+    });
+    
+    it('should pass', () => {
+      assert.ok(true);
+    });
+    
+  });
+  
+});


### PR DESCRIPTION
Adds a test framework to help drive changes with TDD.

Uses [`mocha`](https://mochajs.org/) to run the transpiled tests. The workflow is:

1. Run `gulp watch`.
2. In another shell, run `npm test` to run your tests.

The `setup.test.ts` file will boot up MongoDB if you do not already have an instance running. I recommend you do run one, so the db isn't booted up every time you run your tests.