### PR TITLE
Add attendees management and limit modifications to attendees

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "postinstall": "npm run build",
     "prestart": "npm run build",
     "start": "node bin/server.js",
-    "test": "cd build && mocha --require source-map-support/register --timeout 10000",
+    "test": "cd build && mocha --require source-map-support/register --timeout 5000",
     "prebuild:watch": "npm run prebuild",
     "build:watch": "node node_modules/typescript/bin/tsc -p src/ -w",
-    "test:watch": "cd build && mocha --require source-map-support/register --timeout 10000 -w -R dot"
+    "test:watch": "cd build && mocha --require source-map-support/register --timeout 5000 -w -R dot"
   },
   "dependencies": {
     "body-parser": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "mocha": "^2.4.5",
     "mongodb": "^2.1.7",
+    "promisify-supertest": "^1.0.0",
     "source-map-support": "^0.4.0",
     "supertest": "^1.2.0",
     "typings": "^0.6.8"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "npm run build",
     "prestart": "npm run build",
     "start": "node bin/server.js",
-    "test": "cd build && mocha --require source-map-support/register --timeout 5000",
+    "test": "cd build && mocha --require source-map-support/register --timeout 5000 -R dot",
     "prebuild:watch": "npm run prebuild",
     "build:watch": "node node_modules/typescript/bin/tsc -p src/ -w",
     "test:watch": "cd build && mocha --require source-map-support/register --timeout 5000 -w -R dot"
@@ -18,10 +18,10 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
-    "mongoose": "^4.4.3",
+    "mongoose": "^4.4.5",
     "slug": "^0.9.1",
     "source-map-support": "^0.4.0",
-    "typescript": "^1.7.5"
+    "typescript": "^1.8.7"
   },
   "devDependencies": {
     "mocha": "^2.4.5",
@@ -29,6 +29,6 @@
     "promisify-supertest": "^1.0.0",
     "source-map-support": "^0.4.0",
     "supertest": "^1.2.0",
-    "typings": "^0.6.8"
+    "typings": "^0.6.9"
   }
 }

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -17,6 +17,8 @@ export const UserSchema = new Schema({
 });
 export const UserModel = model<IUserModel>('User', UserSchema);
 
+
+
 export interface ITeam {
   teamid: string;
   name: string;
@@ -35,9 +37,25 @@ export const TeamSchema = new Schema({
 });
 export const TeamModel = model<ITeamModel>('Team', TeamSchema);
 
+
+
+export interface IAttendee {
+  attendeeid: string;
+}
+
+export interface IAttendeeModel extends IAttendee, Document { }
+
+export const AttendeeSchema = new Schema({
+  attendeeid: { type: String, unique: true, required: true },
+});
+export const AttendeeModel = model<IAttendeeModel>('Attendee', AttendeeSchema);
+
+
+
 export interface IModels {
   User: Model<IUserModel>;
   Team: Model<ITeamModel>;
+  Attendee: Model<IAttendeeModel>;
 }
 
 export enum MongoDBErrors {

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -175,6 +175,7 @@ export declare module Root {
       self: string;
       teams: JSONApi.LinkObject;
       users: JSONApi.LinkObject;
+      attendees: JSONApi.LinkObject;
     }
   }
   

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -139,6 +139,32 @@ export declare module TeamMembersRelationship {
   
 }
 
+export declare module AttendeeResource {
+
+  export interface AttributesObject extends JSONApi.AttributesObject {
+    emailaddress: string
+  }
+
+  export interface ResourceObject extends JSONApi.ResourceObject {
+    attributes?: AttributesObject;
+  }
+
+  export interface TopLevelDocument extends JSONApi.TopLevelDocument {
+    links?: JSONApi.LinksObject;
+    data: ResourceObject;
+  }
+  
+}
+
+export declare module AttendeesResource {
+
+  export interface TopLevelDocument extends JSONApi.TopLevelDocument {
+    links?: JSONApi.LinksObject;
+    data: AttendeeResource.ResourceObject[];
+  }
+  
+}
+
 export declare module Root {
 
   export interface TopLevelDocument extends JSONApi.TopLevelDocument {

--- a/src/server/routes/attendees.ts
+++ b/src/server/routes/attendees.ts
@@ -41,7 +41,7 @@ export function GetAll(req: RequestWithModels, res: Response) {
     .then((attendees) => {
       
       const attendeesData = attendees.map<AttendeeResource.ResourceObject>((attendee) => ({
-        links: { self: `/teams/${encodeURIComponent(attendee.attendeeid)}` },
+        links: { self: `/attendees/${encodeURIComponent(attendee.attendeeid)}` },
         type: 'attendees',
         id: attendee.attendeeid
       }));

--- a/src/server/routes/attendees.ts
+++ b/src/server/routes/attendees.ts
@@ -101,9 +101,12 @@ export function Delete(req: RequestWithModels, res: Response) {
     return respond.Send400(res);
     
   req.models.Attendee
-    .findOneAndRemove({ attendeeid: attendeeid })
+    .findOneAndRemove({ attendeeid: attendeeid }, { select: '_id' })
     .exec()
-    .then((removedAttendee) => {
+    .then((result) => {
+      if (result === null)
+        return respond.Send404(res);
+        
       respond.Send204(res);
     }, respond.Send500.bind(null, res));
 };

--- a/src/server/routes/attendees.ts
+++ b/src/server/routes/attendees.ts
@@ -1,0 +1,112 @@
+"use strict";
+
+import {Request, Response} from 'express'
+import {IModels, MongoDBErrors} from '../models'
+import * as respond from './respond';
+import {AttendeeResource, AttendeesResource} from '../resources';
+
+declare interface RequestWithModels extends Request {
+  models: IModels
+}
+
+export function Get(req: RequestWithModels, res: Response) {
+  if (req.params.attendeeid === undefined || typeof req.params.attendeeid !== 'string')
+    return respond.Send400(res);
+    
+  req.models.Attendee
+    .findOne({ attendeeid: req.params.attendeeid }, 'attendeeid')
+    .exec()
+    .then((attendee) => {
+      if (!attendee)
+        return respond.Send404(res);
+
+        const attendeeResponse = <AttendeeResource.TopLevelDocument> {
+          links: { self: `/attendees/${encodeURIComponent(attendee.attendeeid)}` },
+          data: {
+            type: 'attendees',
+            id: attendee.attendeeid
+          }
+        };
+
+        res.status(200).contentType('application/vnd.api+json').send(attendeeResponse);
+    }, respond.Send500.bind(res));
+};
+
+export function GetAll(req: RequestWithModels, res: Response) {
+  
+  req.models.Attendee
+    .find({}, 'attendeeid')
+    .sort({ attendeeid: 1 })
+    .exec()
+    .then((attendees) => {
+      
+      const attendeesData = attendees.map<AttendeeResource.ResourceObject>((attendee) => ({
+        links: { self: `/teams/${encodeURIComponent(attendee.attendeeid)}` },
+        type: 'attendees',
+        id: attendee.attendeeid
+      }));
+      
+      const attendeesResponse = <AttendeesResource.TopLevelDocument> {
+        links: {
+          self: '/attendees'
+        },
+        data: attendeesData
+      }
+      
+      respond.Send200(res, attendeesResponse);
+    }, respond.Send500.bind(res));
+};
+
+export function Create(req: RequestWithModels, res: Response) {
+  const requestDoc: AttendeeResource.TopLevelDocument = req.body;
+  
+  if (!requestDoc 
+    || !requestDoc.data
+    || !requestDoc.data.id
+    || typeof requestDoc.data.id !== 'string'
+    || !requestDoc.data.type
+    || requestDoc.data.type !== 'attendees')
+    return respond.Send400(res);
+
+  const attendee = new req.models.Attendee({
+    attendeeid: requestDoc.data.id
+  });
+
+  attendee.save((err) => {
+    if (err) {
+      if (err.code === MongoDBErrors.E11000_DUPLICATE_KEY)
+        return respond.Send409(res);
+
+      return respond.Send500(res);
+    }
+
+    const attendeeResponse = <AttendeeResource.TopLevelDocument> {
+      links: {
+        self: `/attendees/${encodeURIComponent(attendee.attendeeid)}`
+      },
+      data: {
+        type: 'attendees',
+        id: attendee.attendeeid
+      }
+    };
+
+    respond.Send201(res, attendeeResponse);
+  });
+};
+
+export function Delete(req: RequestWithModels, res: Response) {
+  const attendeeid = req.params.attendeeid;
+  
+  if (attendeeid === undefined || typeof attendeeid !== 'string' || attendeeid.length === 0)
+    return respond.Send400(res);
+
+  const attendee = new req.models.Attendee({
+    attendeeid: attendeeid
+  });
+
+  attendee.remove((err) => {
+    if (err) return respond.Send500(res);
+
+    respond.Send204(res);
+  });
+};

--- a/src/server/routes/attendees.ts
+++ b/src/server/routes/attendees.ts
@@ -29,7 +29,7 @@ export function Get(req: RequestWithModels, res: Response) {
         };
 
         res.status(200).contentType('application/vnd.api+json').send(attendeeResponse);
-    }, respond.Send500.bind(res));
+    }, respond.Send500.bind(null, res));
 };
 
 export function GetAll(req: RequestWithModels, res: Response) {
@@ -54,7 +54,7 @@ export function GetAll(req: RequestWithModels, res: Response) {
       }
       
       respond.Send200(res, attendeesResponse);
-    }, respond.Send500.bind(res));
+    }, respond.Send500.bind(null, res));
 };
 
 export function Create(req: RequestWithModels, res: Response) {
@@ -99,14 +99,11 @@ export function Delete(req: RequestWithModels, res: Response) {
   
   if (attendeeid === undefined || typeof attendeeid !== 'string' || attendeeid.length === 0)
     return respond.Send400(res);
-
-  const attendee = new req.models.Attendee({
-    attendeeid: attendeeid
-  });
-
-  attendee.remove((err) => {
-    if (err) return respond.Send500(res);
-
-    respond.Send204(res);
-  });
+    
+  req.models.Attendee
+    .findOneAndRemove({ attendeeid: attendeeid })
+    .exec()
+    .then((removedAttendee) => {
+      respond.Send204(res);
+    }, respond.Send500.bind(null, res));
 };

--- a/src/server/routes/respond.ts
+++ b/src/server/routes/respond.ts
@@ -45,12 +45,12 @@ export function Send401(res: Response) {
      .send(errorResponse);
 }
 
-export function Send403(res: Response, who?: string) {
+export function Send403(res: Response) {
   let errorResponse: JSONApi.TopLevelDocument = {
     errors: [{
       status: '403',
       title: 'Access is forbidden.',
-      detail: `Only ${who || 'hackbot'} has access to do that.`
+      detail: 'You are not permitted to perform that action.'
     }]
   };
   res.status(403)

--- a/src/server/routes/respond.ts
+++ b/src/server/routes/respond.ts
@@ -45,12 +45,12 @@ export function Send401(res: Response) {
      .send(errorResponse);
 }
 
-export function Send403(res: Response) {
+export function Send403(res: Response, who?: string) {
   let errorResponse: JSONApi.TopLevelDocument = {
     errors: [{
       status: '403',
       title: 'Access is forbidden.',
-      detail: 'Only hackbot has access to do that.'
+      detail: `Only ${who || 'hackbot'} has access to do that.`
     }]
   };
   res.status(403)

--- a/src/server/routes/root.ts
+++ b/src/server/routes/root.ts
@@ -16,6 +16,9 @@ export function Get(req: Request, res: Response) {
       },
       users: {
         href: '/users'
+      },
+      attendees: {
+        href: '/attendees'
       }
     }
   }

--- a/src/server/routes/team.members.ts
+++ b/src/server/routes/team.members.ts
@@ -38,7 +38,7 @@ export function Get(req: RequestWithModels, res: Response) {
         included: includedUsers
       };
       respond.Send200(res, membersResponse);
-    }, respond.Send500.bind(res));
+    }, respond.Send500.bind(null, res));
 };
 
 export function Delete(req: RequestWithModels, res: Response) {
@@ -78,7 +78,7 @@ export function Delete(req: RequestWithModels, res: Response) {
         respond.Send204(res);
       });
       
-    }, respond.Send500.bind(res));
+    }, respond.Send500.bind(null, res));
 };
 
 export function Add(req: RequestWithModels, res: Response) {
@@ -139,5 +139,5 @@ export function Add(req: RequestWithModels, res: Response) {
             })
         });
       
-    }, respond.Send500.bind(res));
+    }, respond.Send500.bind(null, res));
 };

--- a/src/server/routes/team.members.ts
+++ b/src/server/routes/team.members.ts
@@ -33,7 +33,7 @@ export function Get(req: RequestWithModels, res: Response) {
       }));
         
       let membersResponse: TeamMembersRelationship.TopLevelDocument = {
-        links: { self: `/teams/${encodeURI(team.teamid)}/members` },
+        links: { self: `/teams/${encodeURIComponent(team.teamid)}/members` },
         data: members,
         included: includedUsers
       };

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -67,8 +67,8 @@ export function GetAll(req: RequestWithModels, res: Response) {
           };
           respond.Send200(res, teamsResponse);
           
-        }, respond.Send500.bind(res));
-    }, respond.Send500.bind(res));
+        }, respond.Send500.bind(null, res));
+    }, respond.Send500.bind(null, res));
 };
 
 export function Get(req: RequestWithModels, res: Response) {
@@ -108,7 +108,7 @@ export function Get(req: RequestWithModels, res: Response) {
         included: includedUsers
       };
       respond.Send200(res, teamResponse);
-    }, respond.Send500.bind(res));
+    }, respond.Send500.bind(null, res));
 };
 
 export function Create(req: RequestWithModels, res: Response) {
@@ -217,10 +217,10 @@ export function Create(req: RequestWithModels, res: Response) {
               }
             };
             respond.Send201(res, teamResponse);
-          }, respond.Send500.bind(res));
+          }, respond.Send500.bind(null, res));
       });
       
-    }, respond.Send500.bind(res));
+    }, respond.Send500.bind(null, res));
 };
 
 export function Update(req: RequestWithModels, res: Response) {
@@ -246,5 +246,5 @@ export function Update(req: RequestWithModels, res: Response) {
   req.models.Team
     .findOneAndUpdate({ teamid: requestDoc.data.id }, updateDoc)
     .exec()
-    .then((team) => respond.Send204(res), respond.Send500.bind(res));
+    .then((team) => respond.Send204(res), respond.Send500.bind(null, res));
 };

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -33,7 +33,7 @@ export function GetAll(req: RequestWithModels, res: Response) {
     .then((teams) => {
       
       const teamResponses = teams.map<TeamResource.ResourceObject>((team) => ({
-        links: { self: `/teams/${encodeURI(team.teamid)}` },
+        links: { self: `/teams/${encodeURIComponent(team.teamid)}` },
         type: 'teams',
         id: team.teamid,
         attributes: {
@@ -42,7 +42,7 @@ export function GetAll(req: RequestWithModels, res: Response) {
         },
         relationships: {
           members: {
-            links: { self: `/teams/${encodeURI(team.teamid)}/members` },
+            links: { self: `/teams/${encodeURIComponent(team.teamid)}/members` },
             data: team.members.map((member) => ({ type: 'users', id: member.userid }))
           }
         }
@@ -90,7 +90,7 @@ export function Get(req: RequestWithModels, res: Response) {
       }));
         
       const teamResponse: TeamResource.TopLevelDocument = {
-        links: { self: `/teams/${encodeURI(team.teamid)}` },
+        links: { self: `/teams/${encodeURIComponent(team.teamid)}` },
         data: {
           type: 'teams',
           id: team.teamid,
@@ -100,7 +100,7 @@ export function Get(req: RequestWithModels, res: Response) {
           },
           relationships: {
             members: {
-              links: { self: `/teams/${encodeURI(team.teamid)}/members` },
+              links: { self: `/teams/${encodeURIComponent(team.teamid)}/members` },
               data: team.members.map((member) => ({ type: 'users', id: member.userid }))
             }
           }
@@ -153,7 +153,7 @@ export function Create(req: RequestWithModels, res: Response) {
       
       const teamResponse: TeamResource.TopLevelDocument = {
         links: {
-          self: `/teams/${encodeURI(team.teamid)}`
+          self: `/teams/${encodeURIComponent(team.teamid)}`
         },
         data: {
           type: 'teams',
@@ -164,7 +164,7 @@ export function Create(req: RequestWithModels, res: Response) {
           },
           relationships: {
             members: {
-              links: { self: `/teams/${encodeURI(team.teamid)}/members` },
+              links: { self: `/teams/${encodeURIComponent(team.teamid)}/members` },
               data: null
             }
           }
@@ -200,7 +200,7 @@ export function Create(req: RequestWithModels, res: Response) {
           .exec()
           .then((team) => {
             const teamResponse: TeamResource.TopLevelDocument = {
-              links: { self: `/teams/${encodeURI(team.teamid)}` },
+              links: { self: `/teams/${encodeURIComponent(team.teamid)}` },
               data: {
                 type: 'teams',
                 id: team.teamid,
@@ -210,7 +210,7 @@ export function Create(req: RequestWithModels, res: Response) {
                 },
                 relationships: {
                   members: {
-                    links: { self: `/teams/${encodeURI(team.teamid)}/members` },
+                    links: { self: `/teams/${encodeURIComponent(team.teamid)}/members` },
                     data: team.members.map((member) => ({ type: 'users', id: member.userid}))
                   }
                 }

--- a/src/server/routes/users.ts
+++ b/src/server/routes/users.ts
@@ -27,13 +27,13 @@ export function GetAll(req: RequestWithModels, res: Response) {
           const userResponses = users.map((user) => {
             const usersTeam = teams.find((team) => team.members.some((member) => member.userid === user.userid))
             const userResponse: UserResource.ResourceObject = {
-              links: { self: `/users/${encodeURI(user.userid)}` },
+              links: { self: `/users/${encodeURIComponent(user.userid)}` },
               type: 'users',
               id: user.userid,
               attributes: { name: user.name },
               relationships: {
                 team: {
-                  links: { self: `/users/${encodeURI(user.userid)}/team` },
+                  links: { self: `/users/${encodeURIComponent(user.userid)}/team` },
                   data: usersTeam ? { type: 'teams', id: usersTeam.teamid } : null
                 }
               }
@@ -42,7 +42,7 @@ export function GetAll(req: RequestWithModels, res: Response) {
           });
 
           const includedTeams = teams.map<TeamResource.ResourceObject>((team) => ({
-            links: { self: `/teams/${encodeURI(team.teamid)}` },
+            links: { self: `/teams/${encodeURIComponent(team.teamid)}` },
             type: 'teams',
             id: team.teamid,
             attributes: {
@@ -51,7 +51,7 @@ export function GetAll(req: RequestWithModels, res: Response) {
             },
             relationships: {
               members: {
-                links: { self: `/teams/${encodeURI(team.teamid)}/members` },
+                links: { self: `/teams/${encodeURIComponent(team.teamid)}/members` },
                 data: team.members ? team.members.map((member) => ({ type: 'users', id: member.userid })) : []
               }
             }
@@ -68,7 +68,7 @@ export function GetAll(req: RequestWithModels, res: Response) {
     }, respond.Send500.bind(res));
 };
 
-export function GetByUserId(req: RequestWithModels, res: Response) {
+export function Get(req: RequestWithModels, res: Response) {
   if (req.params.userid === undefined || typeof req.params.userid !== 'string')
     return respond.Send400(res);
 
@@ -85,14 +85,14 @@ export function GetByUserId(req: RequestWithModels, res: Response) {
         .exec()
         .then((team) => {
           const userResponse = <UserResource.TopLevelDocument> {
-            links: { self: `/users/${encodeURI(user.userid)}` },
+            links: { self: `/users/${encodeURIComponent(user.userid)}` },
             data: {
               type: 'users',
               id: user.userid,
               attributes: { name: user.name },
               relationships: {
                 team: {
-                  links: { self: `/users/${encodeURI(user.userid)}/team` },
+                  links: { self: `/users/${encodeURIComponent(user.userid)}/team` },
                   data: null
                 }
               }
@@ -104,13 +104,13 @@ export function GetByUserId(req: RequestWithModels, res: Response) {
             userResponse.data.relationships.team.data = { type: 'teams', id: team.teamid };
 
             const includedTeam = <TeamResource.ResourceObject> {
-              links: { self: `/teams/${encodeURI(team.teamid)}` },
+              links: { self: `/teams/${encodeURIComponent(team.teamid)}` },
               type: 'teams',
               id: team.teamid,
               attributes: { name: team.name, motto: team.motto },
               relationships: {
                 members: {
-                  links: { self: `/teams/${encodeURI(team.teamid)}/members` },
+                  links: { self: `/teams/${encodeURIComponent(team.teamid)}/members` },
                   data: team.members ? team.members.map((member) => ({ type: 'users', id: member.userid })) : []
                 }
               }
@@ -119,13 +119,13 @@ export function GetByUserId(req: RequestWithModels, res: Response) {
             const includedUsers = team.members
               .filter((member) => member.userid !== user.userid)
               .map<UserResource.ResourceObject>((member) => ({
-                links: { self: `/users/${encodeURI(member.userid)}` },
+                links: { self: `/users/${encodeURIComponent(member.userid)}` },
                 type: 'users',
                 id: member.userid,
                 attributes: { name: member.name },
                 relationships: {
                   team: {
-                    links: { self: `/teams/${encodeURI(team.teamid)}` },
+                    links: { self: `/teams/${encodeURIComponent(team.teamid)}` },
                     data: { type: 'teams', id: team.teamid }
                   }
                 }
@@ -168,7 +168,7 @@ export function Create(req: RequestWithModels, res: Response) {
 
     const userResponse = <UserResource.TopLevelDocument> {
       links: {
-        self: `/users/${encodeURI(user.userid)}`
+        self: `/users/${encodeURIComponent(user.userid)}`
       },
       data: {
         type: 'users',
@@ -179,7 +179,7 @@ export function Create(req: RequestWithModels, res: Response) {
         relationships: {
           team: {
             links: {
-              self: `/users/${encodeURI(user.userid)}/team`
+              self: `/users/${encodeURIComponent(user.userid)}/team`
             },
             data: null
           }

--- a/src/server/routes/users.ts
+++ b/src/server/routes/users.ts
@@ -64,8 +64,8 @@ export function GetAll(req: RequestWithModels, res: Response) {
           };
           
           respond.Send200(res, usersResponse);
-        }, respond.Send500.bind(res))
-    }, respond.Send500.bind(res));
+        }, respond.Send500.bind(null, res))
+    }, respond.Send500.bind(null, res));
 };
 
 export function Get(req: RequestWithModels, res: Response) {
@@ -135,8 +135,8 @@ export function Get(req: RequestWithModels, res: Response) {
           }
 
           res.status(200).contentType('application/vnd.api+json').send(userResponse);
-        }, respond.Send500.bind(res))
-    }, respond.Send500.bind(res));
+        }, respond.Send500.bind(null, res))
+    }, respond.Send500.bind(null, res));
 };
 
 export function Create(req: RequestWithModels, res: Response) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -80,7 +80,7 @@ function requiresAttendeeUser(req: IUnauthorisedRequest, res: Response, next: Fu
         return respond.Send403(res);
         
       next();
-    }, respond.Send500.bind(res))
+    }, respond.Send500.bind(null, res))
 }
 
 export interface ServerInfo {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -15,7 +15,6 @@ import * as respond from './routes/respond'
 
 const AuthorisedUsers = {
   Hackbot: {
-    Username: process.env.HACKBOT_USERNAME || 'hackbot',
     Password: process.env.HACKBOT_PASSWORD || 'h4c6b07'
   },
   Admin: {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5,22 +5,42 @@ import {Server as HttpServer} from 'http';
 import * as mongoose from 'mongoose';
 import * as UsersRoute from './routes/users';
 import * as TeamsRoute from './routes/teams';
+import * as AttendeesRoute from './routes/attendees';
 import * as TeamMembersRoute from './routes/team.members';
 import * as Root from './routes/root';
-import {UserModel, TeamModel} from './models';
+import {UserModel, TeamModel, AttendeeModel} from './models';
 import {json as jsonParser} from 'body-parser';
 import {Request, Response} from 'express';
 import * as respond from './routes/respond'
 
+const AuthorisedUsers = {
+  Hackbot: {
+    Username: process.env.HACKBOT_USERNAME || 'hackbot',
+    Password: process.env.HACKBOT_PASSWORD || 'h4c6b07'
+  },
+  Admin: {
+    Username: process.env.ADMIN_USERNAME || 'admin',
+    Password: process.env.ADMIN_PASSWORD || '4d3in'
+  }
+};
+
+declare interface IUnauthorisedRequest extends Request {
+  AuthParts: {
+    Username: string;
+    Password: string;
+  }
+}
+
 function createModels(req, res, next) {
   req.models = {
     User: UserModel,
-    Team: TeamModel
+    Team: TeamModel,
+    Attendee: AttendeeModel
   };
   return next();
 }
 
-function requiresHackbotUser(req: Request, res: Response, next: Function) {
+function requiresUser(req: IUnauthorisedRequest, res: Response, next: Function) {
   if (req.headers['authorization'] === undefined)
     return respond.Send401(res);
     
@@ -33,8 +53,24 @@ function requiresHackbotUser(req: Request, res: Response, next: Function) {
   if (decodedParts.length < 2)
     return respond.Send403(res);
   
-  if (decodedParts[0] !== process.env.HACKBOT_USERNAME || decodedParts[1] !== process.env.HACKBOT_PASSWORD)
+  req.AuthParts = {
+    Username: decodedParts[0],
+    Password: decodedParts[1]
+  };
+  
+  next();
+}
+
+function requiresHackbotUser(req: IUnauthorisedRequest, res: Response, next: Function) {
+  if (req.AuthParts.Username !== AuthorisedUsers.Hackbot.Username || req.AuthParts.Password !== AuthorisedUsers.Hackbot.Password)
     return respond.Send403(res);
+  
+  next();
+}
+
+function requiresAdminUser(req: IUnauthorisedRequest, res: Response, next: Function) {
+  if (req.AuthParts.Username !== AuthorisedUsers.Admin.Username || req.AuthParts.Password !== AuthorisedUsers.Admin.Password)
+    return respond.Send403(res, 'admin');
   
   next();
 }
@@ -53,21 +89,29 @@ export class Server {
 
     this._app = express();
 
-    this._app.get('/users/', createModels, UsersRoute.GetAll);
-    this._app.post('/users/', requiresHackbotUser, apiJsonParser, createModels, UsersRoute.Create);
+    this._app.get('/users', createModels, UsersRoute.GetAll);
+    this._app.post('/users', requiresUser, requiresHackbotUser, apiJsonParser, createModels, UsersRoute.Create);
     
-    this._app.get('/users/:userid', apiJsonParser, createModels, UsersRoute.GetByUserId);
+    this._app.get('/users/:userid', createModels, UsersRoute.Get);
     
-    this._app.post('/teams/:teamId/members', requiresHackbotUser, apiJsonParser, createModels, TeamMembersRoute.Add);
-    this._app.delete('/teams/:teamId/members', requiresHackbotUser, apiJsonParser, createModels, TeamMembersRoute.Delete);
+    
+    this._app.post('/teams/:teamId/members', requiresUser, requiresHackbotUser, apiJsonParser, createModels, TeamMembersRoute.Add);
+    this._app.delete('/teams/:teamId/members', requiresUser, requiresHackbotUser, apiJsonParser, createModels, TeamMembersRoute.Delete);
     this._app.get('/teams/:teamId/members', createModels, TeamMembersRoute.Get);
 
     
-    this._app.patch('/teams/:teamId', requiresHackbotUser, apiJsonParser, createModels, TeamsRoute.Update);
+    this._app.patch('/teams/:teamId', requiresUser, requiresHackbotUser, apiJsonParser, createModels, TeamsRoute.Update);
     this._app.get('/teams/:teamId', createModels, TeamsRoute.Get);
     
-    this._app.get('/teams/', createModels, TeamsRoute.GetAll);
-    this._app.post('/teams/', requiresHackbotUser, apiJsonParser, createModels, TeamsRoute.Create);
+    
+    this._app.get('/teams', createModels, TeamsRoute.GetAll);
+    this._app.post('/teams', requiresUser, requiresHackbotUser, apiJsonParser, createModels, TeamsRoute.Create);
+    
+    
+    this._app.get('/attendees/:attendeeid', requiresUser, requiresAdminUser, createModels, AttendeesRoute.Get);
+    this._app.delete('/attendees/:attendeeid', requiresUser, requiresAdminUser, createModels, AttendeesRoute.Delete);
+    this._app.get('/attendees', requiresUser, requiresAdminUser, createModels, AttendeesRoute.GetAll);
+    this._app.post('/attendees', requiresUser, requiresAdminUser, apiJsonParser, createModels, AttendeesRoute.Create);
 
     this._app.get('/api', (req, res) => {
       res.send('Hack24 API is running');

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -73,14 +73,15 @@ function requiresAttendeeUser(req: IUnauthorisedRequest, res: Response, next: Fu
     return respond.Send403(res);
     
   AttendeeModel
-    .find({ attendeeid: AuthorisedUsers.Hackbot.Username })
+    .find({ attendeeid: req.AuthParts.Username }, '_id')
+    .limit(1)
     .exec()
-    .then((attendee) => {
-      if (attendee === null)
+    .then((attendees) => {
+      if (attendees.length === 0)
         return respond.Send403(res);
         
       next();
-    });
+    }, respond.Send500.bind(res))
 }
 
 export interface ServerInfo {

--- a/src/test/attendees.test.ts
+++ b/src/test/attendees.test.ts
@@ -321,12 +321,14 @@ describe('Attendees resource', () => {
       let thisAttendee = response.data[0];
       assert.strictEqual(thisAttendee.type, 'attendees');
       assert.strictEqual(thisAttendee.id, attendee.attendeeid);
+      assert.strictEqual(thisAttendee.links.self, `/attendees/${encodeURIComponent(attendee.attendeeid)}`);
     });
 
     it('should return the second attendee', () => {
       let thisAttendee = response.data[1];
       assert.strictEqual(thisAttendee.type, 'attendees');
       assert.strictEqual(thisAttendee.id, otherAttendee.attendeeid);
+      assert.strictEqual(thisAttendee.links.self, `/attendees/${encodeURIComponent(otherAttendee.attendeeid)}`);
     });
     
     after((done) => {

--- a/src/test/attendees.test.ts
+++ b/src/test/attendees.test.ts
@@ -401,6 +401,38 @@ describe('Attendees resource', () => {
 
   });
 
+  describe('DELETE attendee which does not exist', () => {
+
+    let statusCode: number;
+    let contentType: string;
+    let response: JSONApi.TopLevelDocument;
+
+    before(async () => {
+      await api.delete(`/attendees/asdasdasdadasd`)
+        .auth(ApiServer.AdminUsername, ApiServer.AdminPassword)
+        .end()
+        .then(async (res) => {
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+        });
+    });
+
+    it('should respond with status code 404 Not Found', () => {
+      assert.strictEqual(statusCode, 404);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should respond with the expected "Resource not found" error', () => {
+      assert.strictEqual(response.errors.length, 1);
+      assert.strictEqual(response.errors[0].status, '404');
+      assert.strictEqual(response.errors[0].title, 'Resource not found.');
+    });
+  });
+
   describe('DELETE attendee with incorrect auth', () => {
 
     let attendee: IAttendee;

--- a/src/test/attendees.test.ts
+++ b/src/test/attendees.test.ts
@@ -1,0 +1,459 @@
+"use strict";
+
+import * as assert from 'assert';
+import {MongoDB} from './utils/mongodb';
+import {IAttendee} from './models/attendees';
+import {ApiServer} from './utils/apiserver';
+import * as request from 'supertest';
+import {JSONApi, AttendeeResource, AttendeesResource} from './resources'
+
+describe('Attendees resource', () => {
+
+  let api: request.SuperTest;
+
+  before(() => {
+    api = request('http://localhost:' + ApiServer.Port);
+  });
+
+  describe('GET attendee by ID', () => {
+
+    let attendee: IAttendee;
+    let statusCode: number;
+    let contentType: string;
+    let response: AttendeeResource.TopLevelDocument;
+
+    before(async (done) => {
+      attendee = await MongoDB.Attendees.insertRandomAttendee();
+      
+      api.get(`/attendees/${encodeURIComponent(attendee.attendeeid)}`)
+        .auth(ApiServer.AdminUsername, ApiServer.AdminPassword)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+          
+          done();
+        });
+    });
+
+    it('should respond with status code 200 OK', () => {
+      assert.strictEqual(statusCode, 200);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should return the attendee resource object self link', () => {
+      assert.strictEqual(response.links.self, `/attendees/${encodeURIComponent(attendee.attendeeid)}`);
+    });
+
+    it('should return the attendees type', () => {
+      assert.strictEqual(response.data.type, 'attendees');
+    });
+
+    it('should return the attendee id', () => {
+      assert.strictEqual(response.data.id, attendee.attendeeid);
+    });
+
+    after((done) => {
+      MongoDB.Attendees.removeByAttendeeId(attendee.attendeeid).then(done, done);
+    });
+
+  });
+
+  describe('GET attendee by ID with incorrect auth', () => {
+
+    let attendee: IAttendee;
+    let statusCode: number;
+    let contentType: string;
+    let response: AttendeeResource.TopLevelDocument;
+
+    before((done) => {
+      attendee = MongoDB.Attendees.createRandomAttendee();
+      
+      api.get(`/attendees/${encodeURIComponent(attendee.attendeeid)}`)
+        .auth('joe', 'blogs')
+        .end((err, res) => {
+          if (err) return done(err);
+
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+          
+          done();
+        });
+    });
+
+    it('should respond with status code 403 Forbidden', () => {
+      assert.strictEqual(statusCode, 403);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should respond with the expected "Forbidden" error', () => {
+      assert.strictEqual(response.errors.length, 1);
+      assert.strictEqual(response.errors[0].status, '403');
+      assert.strictEqual(response.errors[0].title, 'Access is forbidden.');
+      assert.strictEqual(response.errors[0].detail, 'Only admin has access to do that.');
+    });
+
+    after((done) => {
+      MongoDB.Attendees.removeByAttendeeId(attendee.attendeeid).then(done, done);
+    });
+
+  });
+
+  describe('POST new attendee', () => {
+
+    let attendee: IAttendee;
+    let createdAttendee: IAttendee;
+    let statusCode: number;
+    let contentType: string;
+    let response: AttendeeResource.TopLevelDocument;
+
+    before((done) => {
+      attendee = MongoDB.Attendees.createRandomAttendee();
+      
+      let requestDoc: AttendeeResource.TopLevelDocument = {
+        data: {
+          type: 'attendees',
+          id: attendee.attendeeid
+        }
+      };
+
+      api.post('/attendees')
+        .auth(ApiServer.AdminUsername, ApiServer.AdminPassword)
+        .send(requestDoc)
+        .type('application/vnd.api+json')
+        .end(async (err, res) => {
+          if (err) return done(err);
+          
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+
+          createdAttendee = await MongoDB.Attendees.findbyAttendeeId(attendee.attendeeid);
+          done();
+        });
+    });
+
+    it('should respond with status code 201 Created', () => {
+      assert.strictEqual(statusCode, 201);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should return the attendee resource object self link', () => {
+      assert.strictEqual(response.links.self, `/attendees/${encodeURIComponent( attendee.attendeeid)}`);
+    });
+
+    it('should return the attendees type', () => {
+      assert.strictEqual(response.data.type, 'attendees');
+    });
+
+    it('should return the attendee id', () => {
+      assert.strictEqual(response.data.id, attendee.attendeeid);
+    });
+
+    after((done) => {
+      MongoDB.Attendees.removeByAttendeeId(attendee.attendeeid).then(done).catch(done);
+    });
+
+  });
+
+  describe('POST new attendee with incorrect auth', () => {
+
+    let attendee: IAttendee;
+    let statusCode: number;
+    let contentType: string;
+    let response: AttendeeResource.TopLevelDocument;
+
+    before((done) => {
+       attendee = MongoDB.Attendees.createRandomAttendee();
+      
+      let requestDoc: AttendeeResource.TopLevelDocument = {
+        data: {
+          type: 'attendees',
+          id: attendee.attendeeid
+        }
+      };
+
+      api.post('/attendees')
+        .auth('gary', 'adam')
+        .send(requestDoc)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+          
+          done();
+        });
+    });
+
+    it('should respond with status code 403 Forbidden', () => {
+      assert.strictEqual(statusCode, 403);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should respond with the expected "Forbidden" error', () => {
+      assert.strictEqual(response.errors.length, 1);
+      assert.strictEqual(response.errors[0].status, '403');
+      assert.strictEqual(response.errors[0].title, 'Access is forbidden.');
+      assert.strictEqual(response.errors[0].detail, 'Only admin has access to do that.');
+    });
+
+    it('should not create the attendee document', (done) => {
+      MongoDB.Attendees.findbyAttendeeId(attendee.attendeeid).then((attendee) => {
+        done(attendee ? new Error('Attendee was created') : null);
+      }).catch(done);
+    });
+
+    after((done) => {
+      MongoDB.Attendees.removeByAttendeeId(attendee.attendeeid).then(done, done);
+    });
+
+  });
+
+  describe('POST attendee with existing ID', () => {
+
+    let attendee: IAttendee;
+    let statusCode: number;
+    let contentType: string;
+    let response: JSONApi.TopLevelDocument;
+
+    before(async (done) => {
+      attendee = await MongoDB.Attendees.insertRandomAttendee();
+      
+      let requestDoc: AttendeeResource.TopLevelDocument = {
+        data: {
+          type: 'attendees',
+          id: attendee.attendeeid
+        }
+      };
+
+      api.post('/attendees')
+        .auth(ApiServer.AdminUsername, ApiServer.AdminPassword)
+        .type('application/vnd.api+json')
+        .send(requestDoc)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+
+          done();
+        });
+    });
+
+    it('should respond with status code 409 Conflict', () => {
+      assert.strictEqual(statusCode, 409);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should return an error with status code 409 and the expected title', () => {
+      assert.strictEqual(response.errors.length, 1);
+      assert.strictEqual(response.errors[0].status, '409');
+      assert.strictEqual(response.errors[0].title, 'Resource ID already exists.');
+    });
+
+    after((done) => {
+      MongoDB.Attendees.removeByAttendeeId(attendee.attendeeid).then(done, done);
+    });
+
+  });
+  
+  describe('GET attendees', () => {
+
+    let attendee: IAttendee;
+    let otherAttendee: IAttendee;
+    let statusCode: number;
+    let contentType: string;
+    let response: AttendeesResource.TopLevelDocument;
+
+    before(async (done) => {
+      await MongoDB.Attendees.removeAll();
+      
+      attendee = await MongoDB.Attendees.insertRandomAttendee('A');
+      otherAttendee = await MongoDB.Attendees.insertRandomAttendee('B');
+      
+      api.get('/attendees')
+        .auth(ApiServer.AdminUsername, ApiServer.AdminPassword)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+          
+          done();
+        });
+    });
+
+    it('should respond with status code 200 OK', () => {
+      assert.strictEqual(statusCode, 200);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should return the attendees resource object self link', () => {
+      assert.strictEqual(response.links.self, '/attendees');
+    });
+
+    it('should return the first attendee', () => {
+      let thisAttendee = response.data[0];
+      assert.strictEqual(thisAttendee.type, 'attendees');
+      assert.strictEqual(thisAttendee.id, attendee.attendeeid);
+    });
+
+    it('should return the second attendee', () => {
+      let thisAttendee = response.data[1];
+      assert.strictEqual(thisAttendee.type, 'attendees');
+      assert.strictEqual(thisAttendee.id, otherAttendee.attendeeid);
+    });
+    
+    after((done) => {
+      Promise.all([
+        MongoDB.Teams.removeByTeamId(attendee.attendeeid),
+        MongoDB.Users.removeByUserId(otherAttendee.attendeeid)
+      ]).then(() => done(), done);
+    });
+
+  });
+  
+  describe('GET attendees with incorrect auth', () => {
+
+    let statusCode: number;
+    let contentType: string;
+    let response: AttendeesResource.TopLevelDocument;
+
+    before(async (done) => {
+      api.get('/attendees')
+        .auth('zippy', 'bungle')
+        .end((err, res) => {
+          if (err) return done(err);
+
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+          
+          done();
+        });
+    });
+
+    it('should respond with status code 403 Forbidden', () => {
+      assert.strictEqual(statusCode, 403);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should respond with the expected "Forbidden" error', () => {
+      assert.strictEqual(response.errors.length, 1);
+      assert.strictEqual(response.errors[0].status, '403');
+      assert.strictEqual(response.errors[0].title, 'Access is forbidden.');
+      assert.strictEqual(response.errors[0].detail, 'Only admin has access to do that.');
+    });
+
+  });
+
+  describe('DELETE attendee', () => {
+
+    let attendee: IAttendee;
+    let statusCode: number;
+    let contentType: string;
+    let body: string;
+
+    before(async (done) => {
+      attendee = await MongoDB.Attendees.insertRandomAttendee();
+      
+      api.delete(`/attendees/${encodeURIComponent(attendee.attendeeid)}`)
+        .auth(ApiServer.AdminUsername, ApiServer.AdminPassword)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          body = res.text;
+
+          done();
+        });
+    });
+
+    it('should respond with status code 204 No Content', () => {
+      assert.strictEqual(statusCode, 204);
+    });
+
+    it('should return no content-type', () => {
+      assert.strictEqual(contentType, undefined);
+    });
+
+    it('should return no body', () => {
+      assert.strictEqual(body, '');
+    });
+
+    after((done) => {
+      MongoDB.Attendees.removeByAttendeeId(attendee.attendeeid).then(done, done);
+    });
+
+  });
+
+  describe('DELETE attendee with incorrect auth', () => {
+
+    let attendee: IAttendee;
+    let statusCode: number;
+    let contentType: string;
+    let response: JSONApi.TopLevelDocument;
+
+    before(async (done) => {
+      attendee = MongoDB.Attendees.createRandomAttendee();
+      
+      api.delete(`/attendees/${encodeURIComponent(attendee.attendeeid)}`)
+        .auth('sack', 'boy')
+        .end((err, res) => {
+          if (err) return done(err);
+
+          statusCode = res.status;
+          contentType = res.header['content-type'];
+          response = res.body;
+
+          done();
+        });
+    });
+
+    it('should respond with status code 403 Forbidden', () => {
+      assert.strictEqual(statusCode, 403);
+    });
+
+    it('should return application/vnd.api+json content with charset utf-8', () => {
+      assert.strictEqual(contentType, 'application/vnd.api+json; charset=utf-8');
+    });
+
+    it('should respond with the expected "Forbidden" error', () => {
+      assert.strictEqual(response.errors.length, 1);
+      assert.strictEqual(response.errors[0].status, '403');
+      assert.strictEqual(response.errors[0].title, 'Access is forbidden.');
+      assert.strictEqual(response.errors[0].detail, 'Only admin has access to do that.');
+    });
+
+  });
+  
+});

--- a/src/test/attendees.test.ts
+++ b/src/test/attendees.test.ts
@@ -359,6 +359,7 @@ describe('Attendees resource', () => {
   describe('DELETE attendee', () => {
 
     let attendee: IAttendee;
+    let deletedAttendee: IAttendee;
     let statusCode: number;
     let contentType: string;
     let body: string;
@@ -369,10 +370,12 @@ describe('Attendees resource', () => {
       await api.delete(`/attendees/${encodeURIComponent(attendee.attendeeid)}`)
         .auth(ApiServer.AdminUsername, ApiServer.AdminPassword)
         .end()
-        .then((res) => {
+        .then(async (res) => {
           statusCode = res.status;
           contentType = res.header['content-type'];
           body = res.text;
+
+          deletedAttendee = await MongoDB.Attendees.findbyAttendeeId(attendee.attendeeid);
         });
     });
 
@@ -386,6 +389,10 @@ describe('Attendees resource', () => {
 
     it('should return no body', () => {
       assert.strictEqual(body, '');
+    });
+    
+    it('should have deleted the attendee', () => {
+      assert.strictEqual(deletedAttendee, null);
     });
 
     after(async () => {

--- a/src/test/models/attendees.ts
+++ b/src/test/models/attendees.ts
@@ -1,0 +1,84 @@
+"use strict";
+
+import {Db, Collection, ObjectID} from 'mongodb';
+import {Random} from '../utils/random';
+
+export interface IAttendee {
+  _id?: ObjectID;
+  attendeeid: string;
+}
+
+export class Attendees {
+  private _collection: Collection;
+  
+  public static Create(db: Db): Promise<Attendees> {
+    return new Promise<Attendees>((resolve, reject) => {
+      var attendees = new Attendees();
+      db.collection('attendees', (err, collection) => {
+        if (err) return reject(err);
+        attendees._collection = collection;
+        resolve(attendees);
+      });
+    });
+  }
+  
+  public removeAll(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this._collection.deleteMany({}).then(() => {
+        resolve();
+      }).catch((err) => {
+        reject(new Error('Could not remove all attendees: ' + err.message));
+      })
+    });
+  }
+  
+  public removeByAttendeeId(attendeeid: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this._collection.deleteOne({ attendeeid: attendeeid}).then(() => {
+        resolve();
+      }).catch((err) => {
+        reject(new Error('Could not remove attendee: ' + err.message));
+      })
+    });
+  }
+  
+  public createRandomAttendee(prefix?: string): IAttendee {
+    prefix = prefix || '';
+    let randomPart = Random.str(5);
+    return {
+      attendeeid: `testattendee+${prefix}${randomPart}@hack24.co.uk`
+    };
+  }
+  
+  public insertAttendee(attendee: IAttendee): Promise<ObjectID> {
+    return new Promise<ObjectID>((resolve, reject) => {
+      this._collection.insertOne(attendee).then((result) => {
+        resolve(result.insertedId);
+      }).catch((err) => {
+        reject(new Error('Could not insert attendee: ' + err.message));
+      })
+    });
+  }
+  
+  public insertRandomAttendee(prefix?: string): Promise<IAttendee> {
+    let randomAttendee = this.createRandomAttendee(prefix);
+    return new Promise<IAttendee>((resolve, reject) => {
+      this._collection.insertOne(randomAttendee).then((result) => {
+        randomAttendee._id = result.insertedId;
+        resolve(randomAttendee);
+      }).catch((err) => {
+        reject(new Error('Could not insert random attendee: ' + err.message));
+      })
+    });
+  }
+  
+  public findbyAttendeeId(attendeeid: string): Promise<IAttendee> {
+    return new Promise<IAttendee>((resolve, reject) => {
+      this._collection.find({ attendeeid: attendeeid }).limit(1).toArray().then((attendees: IAttendee[]) => {
+        resolve(attendees.length > 0 ? attendees[0] : null);
+      }).catch((err) => {
+        reject(new Error('Error when finding attendee: ' + err.message));
+      });
+    });
+  }
+}

--- a/src/test/resources.ts
+++ b/src/test/resources.ts
@@ -175,6 +175,7 @@ export declare module Root {
       self: string;
       teams: JSONApi.LinkObject;
       users: JSONApi.LinkObject;
+      attendees: JSONApi.LinkObject;
     }
   }
   

--- a/src/test/resources.ts
+++ b/src/test/resources.ts
@@ -139,6 +139,32 @@ export declare module TeamMembersRelationship {
   
 }
 
+export declare module AttendeeResource {
+
+  export interface AttributesObject extends JSONApi.AttributesObject {
+    emailaddress: string
+  }
+
+  export interface ResourceObject extends JSONApi.ResourceObject {
+    attributes?: AttributesObject;
+  }
+
+  export interface TopLevelDocument extends JSONApi.TopLevelDocument {
+    links?: JSONApi.LinksObject;
+    data: ResourceObject;
+  }
+  
+}
+
+export declare module AttendeesResource {
+
+  export interface TopLevelDocument extends JSONApi.TopLevelDocument {
+    links?: JSONApi.LinksObject;
+    data: AttendeeResource.ResourceObject[];
+  }
+  
+}
+
 export declare module Root {
 
   export interface TopLevelDocument extends JSONApi.TopLevelDocument {

--- a/src/test/root.test.ts
+++ b/src/test/root.test.ts
@@ -53,6 +53,10 @@ describe('Teams resource', () => {
     it('should return the users link', () => {
       assert.strictEqual(response.links.users.href, '/users');
     });
+
+    it('should return the attendees link', () => {
+      assert.strictEqual(response.links.attendees.href, '/attendees');
+    });
     
   });
 

--- a/src/test/root.test.ts
+++ b/src/test/root.test.ts
@@ -19,17 +19,14 @@ describe('Teams resource', () => {
     let contentType: string;
     let response: Root.TopLevelDocument;
 
-    before((done) => {
+    before(async () => {
       
-      api.get('/')
-        .end((err, res) => {
-          if (err) return done(err);
-
+      await api.get('/')
+        .end()
+        .then((res) => {
           statusCode = res.status;
           contentType = res.header['content-type'];
           response = res.body;
-          
-          done();
         });
     });
 

--- a/src/test/setup.test.ts
+++ b/src/test/setup.test.ts
@@ -1,17 +1,12 @@
+import 'promisify-supertest';
 import {ApiServer} from './utils/apiserver';
 import {MongoDB} from './utils/mongodb';
 
-before(async (done) => {
-  try {
-    await MongoDB.ensureRunning();
-    await ApiServer.start();
-    done();
-  } catch (err) {
-    done(err);
-  }
+before(async () => {
+  await MongoDB.ensureRunning();
+  await ApiServer.start();
 });
 
-after((done) => {
+after(() => {
   ApiServer.stop();
-  done();
 });

--- a/src/test/supertest.d.ts
+++ b/src/test/supertest.d.ts
@@ -33,7 +33,10 @@ declare module "supertest" {
       expect(field: string, val: string, callback?: CallbackHandler): Test;
       expect(field: string, val: RegExp, callback?: CallbackHandler): Test;
       expect(checker: (res: Response) => any): Test;
-      end(callback?: CallbackHandler): Test;
+      end(callback: CallbackHandler): Test;
+      
+      // to support promisify-supertest
+      end(): Promise<supertest.Response>;
     }
 
     interface Response extends superagent.Response {

--- a/src/test/utils/apiserver.ts
+++ b/src/test/utils/apiserver.ts
@@ -5,17 +5,12 @@ import {fork, ChildProcess} from 'child_process';
 export class ApiServer {
   private static _api: ChildProcess;
   private static _port: number = 12123;
-  private static _hackbotUsername: string = 'username123456789';
   private static _hackbotPassword: string = 'password123456789';
   private static _adminUsername: string = 'admin_user123456789';
   private static _adminPassword: string = 'admin_pass123456789';
   
   public static get Port(): number {
     return this._port;
-  }
-  
-  public static get HackbotUsername(): string {
-    return this._hackbotUsername;
   }
   
   public static get HackbotPassword(): string {
@@ -38,7 +33,6 @@ export class ApiServer {
         cwd: process.cwd(),
         env: {
           PORT: this._port,
-          HACKBOT_USERNAME: this._hackbotUsername,
           HACKBOT_PASSWORD: this._hackbotPassword,
           ADMIN_USERNAME: this._adminUsername,
           ADMIN_PASSWORD: this._adminPassword

--- a/src/test/utils/apiserver.ts
+++ b/src/test/utils/apiserver.ts
@@ -7,6 +7,8 @@ export class ApiServer {
   private static _port: number = 12123;
   private static _hackbotUsername: string = 'username123456789';
   private static _hackbotPassword: string = 'password123456789';
+  private static _adminUsername: string = 'admin_user123456789';
+  private static _adminPassword: string = 'admin_pass123456789';
   
   public static get Port(): number {
     return this._port;
@@ -20,6 +22,14 @@ export class ApiServer {
     return this._hackbotPassword;
   }
   
+  public static get AdminUsername(): string {
+    return this._adminUsername;
+  }
+  
+  public static get AdminPassword(): string {
+    return this._adminPassword;
+  }
+  
   static start() {
     
     return new Promise<void>((resolve, reject) => {
@@ -29,7 +39,9 @@ export class ApiServer {
         env: {
           PORT: this._port,
           HACKBOT_USERNAME: this._hackbotUsername,
-          HACKBOT_PASSWORD: this._hackbotPassword
+          HACKBOT_PASSWORD: this._hackbotPassword,
+          ADMIN_USERNAME: this._adminUsername,
+          ADMIN_PASSWORD: this._adminPassword
         },
         silent: true
       });
@@ -51,7 +63,6 @@ export class ApiServer {
     
       this._api.on('close', function (code) {
         if (code !== null && code !== 0) return console.error(new Error('API closed with non-zero exit code (' + code + ')'));
-        console.log('API closed.');
       });
     
       this._api.on('error', (err) => {

--- a/src/test/utils/mongodb.ts
+++ b/src/test/utils/mongodb.ts
@@ -30,7 +30,12 @@ export class MongoDB {
   }
   
   static async ensureRunning() {
-    const db = await this.connectMongo();
+    let db: Db;
+    try {
+      db = await this.connectMongo();
+    } catch (err) {
+      throw new Error(`Unable to connect to MongoDB - ${err.message}`)
+    }
     await this.prepareDb(db);
   }
   

--- a/src/typings.json
+++ b/src/typings.json
@@ -2,14 +2,14 @@
   "dependencies": {},
   "devDependencies": {},
   "ambientDependencies": {
-    "mocha": "github:DefinitelyTyped/DefinitelyTyped/mocha/mocha.d.ts#d6dd320291705694ba8e1a79497a908e9f5e6617",
-    "mongodb": "github:DefinitelyTyped/DefinitelyTyped/mongodb/mongodb.d.ts#a80a024f79575373c781e5867debcbbad041a3a2",
-    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#1c56e368e17bb28ca57577250624ca5bd561aa81",
-    "superagent": "github:DefinitelyTyped/DefinitelyTyped/superagent/superagent.d.ts#b30dbc4dd32b3237cd78e9139c3fc270caaacacb",
     "body-parser": "github:DefinitelyTyped/DefinitelyTyped/body-parser/body-parser.d.ts#9a2c50ea846ee6ae36feaea0accc77ae7b08a748",
     "express": "github:DefinitelyTyped/DefinitelyTyped/express/express.d.ts#dd4626a4e23ce8d6d175e0fe8244a99771c8c3f2",
     "mime": "github:DefinitelyTyped/DefinitelyTyped/mime/mime.d.ts#cb5206a8ac1c9a3ddfd126f5ecea6729b2361452",
+    "mocha": "github:DefinitelyTyped/DefinitelyTyped/mocha/mocha.d.ts#d6dd320291705694ba8e1a79497a908e9f5e6617",
+    "mongodb": "github:DefinitelyTyped/DefinitelyTyped/mongodb/mongodb.d.ts#a80a024f79575373c781e5867debcbbad041a3a2",
     "mongoose": "github:DefinitelyTyped/DefinitelyTyped/mongoose/mongoose.d.ts#97ec10cb6c917dce7668f3833679506162c0f5c4",
-    "serve-static": "github:DefinitelyTyped/DefinitelyTyped/serve-static/serve-static.d.ts#0fa4e9e61385646ea6a4cba2aef357353d2ce77f"
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#1c56e368e17bb28ca57577250624ca5bd561aa81",
+    "serve-static": "github:DefinitelyTyped/DefinitelyTyped/serve-static/serve-static.d.ts#0fa4e9e61385646ea6a4cba2aef357353d2ce77f",
+    "superagent": "github:DefinitelyTyped/DefinitelyTyped/superagent/superagent.d.ts#b30dbc4dd32b3237cd78e9139c3fc270caaacacb"
   }
 }


### PR DESCRIPTION
Adds `/attendees` to be used as a permission set for allowing team-based actions.

This change replaces the previous authorisation system and replaces it with two new ones:
* Email address username and Hackbot password for team actions
* Admin username and admin password for attendee management

Basically, this locks down any team actions to attendees, who are managed directly by @andrewseward.