### PR TITLE
Improve Heroku stability and logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: node_js
 node_js:
   - "node"
   - "5.4"
+
 services: mongodb
+
+before_script:
+  - npm run build
+
 cache:
   directories:
     - node_modules

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/server

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/server
+web: node bin/server.js

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,9 +1,13 @@
+"use strict";
+
 require('source-map-support').install();
+
+const Log = require('../build/server/logger').Log;
 
 function ensureEnvironment(vars) {
   var missing = vars.filter((val) => process.env[val] === undefined);
   if (missing.length > 0) {
-    missing.forEach((name) => console.error('Environment variable %s is not set', name));
+    missing.forEach((name) => Log.error('Environment variable %s is not set', name));
     process.exit(1);
   }
 }
@@ -19,9 +23,10 @@ var Server = require('../build/server/server.js').Server;
 
 var server = new Server();
 server.listen().then((info) => {
-  console.log(`Server started on port ${info.Port}`);
+  Log.info(`Server started on port ${info.Port}`);
+  process.send('started');
 }).catch((err) => {
-  console.error('Server could not be started');
-  console.error(err);
+  Log.error('Server could not be started');
+  Log.error(err);
   process.exit(1);
 });

--- a/bin/server.js
+++ b/bin/server.js
@@ -24,7 +24,7 @@ var Server = require('../build/server/server.js').Server;
 var server = new Server();
 server.listen().then((info) => {
   Log.info(`Server started on port ${info.Port}`);
-  process.send('started');
+  if (process.send !== undefined) process.send('started');
 }).catch((err) => {
   Log.error('Server could not be started');
   Log.error(err);

--- a/package.json
+++ b/package.json
@@ -3,17 +3,15 @@
   "description": "Hack24 Application",
   "version": "0.0.1",
   "private": true,
-  "main": "src/server/index.js",
+  "main": "bin/server.js",
   "scripts": {
-    "prebuild": "rm -rf build/",
+    "clean": "rm -rf build/",
     "build": "node node_modules/typescript/bin/tsc -p src/",
-    "postinstall": "npm run build",
-    "prestart": "npm run build",
+    "build:watch": "node node_modules/typescript/bin/tsc -p src/ -w",
     "start": "node bin/server.js",
     "test": "cd build && mocha --require source-map-support/register --timeout 5000 -R dot",
-    "prebuild:watch": "npm run prebuild",
-    "build:watch": "node node_modules/typescript/bin/tsc -p src/ -w",
-    "test:watch": "cd build && mocha --require source-map-support/register --timeout 5000 -w -R dot"
+    "test:watch": "cd build && mocha --require source-map-support/register --timeout 5000 -w -R dot",
+    "heroku-postbuild": "npm run build"
   },
   "dependencies": {
     "body-parser": "^1.15.0",

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -2,7 +2,7 @@ import * as morgan from 'morgan'
 import {transports, Logger} from 'winston'
 
 const consoleLogger = new transports.Console({
-  level: 'debug',
+  level: process.env.NODE_ENV === 'production' ? 'error' : process.env.LOG_LEVEL || 'debug',
   timestamp: true,
   handleExceptions: false,
   colorize: process.env.NODE_ENV !== 'production'

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,8 +11,8 @@ import {UsersRoute} from './routes/users';
 import {TeamsRoute} from './routes/teams';
 import {AttendeesRoute} from './routes/attendees';
 import {TeamMembersRoute} from './routes/team.members';
-import {ExpressLogger} from './logger'
-import {EventBroadcaster} from './eventbroadcaster'
+import {ExpressLogger} from './logger';
+import {EventBroadcaster} from './eventbroadcaster';
 
 export interface ServerInfo {
   IP: string
@@ -33,8 +33,7 @@ export class Server {
 
     this._app = express();
     
-    if (process.env.NODE_ENV !== 'production')
-      this._app.use(ExpressLogger);
+    this._app.use(ExpressLogger);
 
     this._app.use('/attendees', attendeesRouter);
     this._app.use('/users', usersRouter);

--- a/src/test/utils/apiserver.ts
+++ b/src/test/utils/apiserver.ts
@@ -66,22 +66,19 @@ export class ApiServer {
         silent: true
       });
       
+      this._api.once('message', () => {
+        resolve();
+      })
+      
       this._api.stderr.on('data', (data: Buffer) => {
         console.log(`!> ${data.toString('utf8')}`);
       });
       
-      let waitingForResolve = true;
-      
       this._api.stdout.on('data', (data: Buffer) => {
-        const dataStr = data.toString('utf8');
-        console.log(`>> ${dataStr}`);
-        if (waitingForResolve && dataStr.startsWith('Server started on port')) {
-          waitingForResolve = false;
-          resolve();
-        }
+        console.log(`#> ${data.toString('utf8')}`);
       });
     
-      this._api.on('close', function (code) {
+      this._api.once('close', function (code) {
         if (code !== null && code !== 0) return console.error(new Error('API closed with non-zero exit code (' + code + ')'));
       });
     


### PR DESCRIPTION
I was having a lot of problems with my API restarting and rebuilding, causing delays on startup.
This change removes the daisy-chained build scripts, in favour of an explicit build step for both Heroku and Travis-CI.

This means that sleeping API instances boot up much faster (like, _really fast_).

To contribute, the following is still the recommended pattern:

1. Run `npm run build:watch` in a shell
2. Open a new shell and run `npm run test:watch`